### PR TITLE
8주차 완료

### DIFF
--- a/HeoWonIl/8week/백트래킹15649.js
+++ b/HeoWonIl/8week/백트래킹15649.js
@@ -1,0 +1,28 @@
+const fs = require("fs");
+const stdin = fs.readFileSync("/dev/stdin").toString().split("\n");
+const input = (() => {
+  let line = 0;
+  return () => stdin[line++];
+})();
+
+const [N, M] = input().split(" ").map(Number);
+const ans = [];
+const ch = Array(N + 1).fill(0);
+
+function dfs(n, arr) {
+  // 종료 조건 및 정답 처리
+  if (n === M) {
+    ans.push(arr);
+    return;
+  }
+  // 본 함수 호출
+  for (let i = 1; i < N + 1; i++) {
+    if (ch[i] === 0) {
+      ch[i] = 1;
+      dfs(n + 1, [...arr, i]);
+      ch[i] = 0;
+    }
+  }
+}
+dfs(0, []);
+ans.forEach((a) => console.log(a.join(" ")));

--- a/HeoWonIl/8week/백트래킹1941.py
+++ b/HeoWonIl/8week/백트래킹1941.py
@@ -1,0 +1,54 @@
+import sys
+input=sys.stdin.readline
+from collections import deque
+
+N=5
+arr=[input() for _ in range(N)]
+ans=0
+ch=[[0]*N for _ in range(N)]
+dx=[-1,0,1,0]
+dy=[0,1,0,-1]
+
+def bfs(a,b):
+    v=[[0]*N for _ in range(N)]
+    q=deque()
+    q.append((a,b))
+    v[a][b]=1
+    adj_cnt=1
+    while q:
+        x,y=q.popleft()
+        for i in range(4):
+            nx=x+dx[i]
+            ny=y+dy[i]
+            if 0<=nx<N and 0<=ny<N and v[nx][ny]==0 and ch[nx][ny]:
+                v[nx][ny]=1
+                adj_cnt+=1
+                q.append((nx,ny))
+    return adj_cnt==7
+    
+def is_adjacent():
+    for i in range(N):
+        for j in range(N):
+            if ch[i][j]==1:
+                return bfs(i,j)
+    
+def dfs(n,cnt,scnt):
+    global ans
+    # 가지 치기
+    if cnt>7:
+        return
+    # 종료 조건
+    if n==N*N:
+        if cnt==7 and scnt>=4: # 7명이고, 이다솜파가 4명 이상인 경우
+            if is_adjacent(): # 7명 모두 인접한 경우만 정답에 추가
+                ans+=1
+        return
+    # n//5, n%5 지점을 포함하는 경우
+    ch[n//N][n%N]=1
+    dfs(n+1,cnt+1,scnt+int(arr[n//N][n%N]=='S'))
+    ch[n//N][n%N]=0
+    # n//5, n%5 지점을 포함하지 않는 경우
+    dfs(n+1,cnt,scnt)
+    
+dfs(0,0,0)
+print(ans)

--- a/HeoWonIl/8week/백트래킹9663.py
+++ b/HeoWonIl/8week/백트래킹9663.py
@@ -1,0 +1,22 @@
+def dfs(i):
+    global ans
+    if i == N:
+        ans += 1
+        return
+    for j in range(N):
+        # 같은 선상에 퀸이 없을 경우 백트래킹 수행
+        if c1[j] == c2[i + j] == c3[i - j] == 0:
+            c1[j] = c2[i + j] = c3[i - j] = 1
+            dfs(i + 1)
+            c1[j] = c2[i + j] = c3[i - j] = 0
+
+
+N = int(input())
+# 같은 선상에 퀸이 있는지 체크
+c1 = [0] * N  # 열
+c2 = [0] * (2 * N - 1)  # 우상향 대각선
+c3 = [0] * (2 * N - 1)  # 우하향 대각선
+ans = 0
+
+dfs(0)
+print(ans)


### PR DESCRIPTION
## 8주차 완료

- 문제 목록
  - 15649 N과 M
  - 9663 N-Queen
  - 1941소문난 칠공주
  <br/>

## 🔎 코드 설명

1941 소문난 칠공주 풀이시, 2차원 배열을 방문 여부를 어떻게 체크할지 전혀 감이 안 잡혔는데, 이 [링크](https://www.youtube.com/results?search_query=%EC%86%8C%EB%AC%B8%EB%82%9C+%EC%B9%A0%EA%B3%B5%EC%A3%BC+%ED%8C%8C%EC%9D%B4%EC%8D%AC)의 강의를 통해 문제의 실마리를 얻을 수 있었습니다. 이는 바로 2차원 배열의 좌표 요소를 (몫, 나머지)를 활용해 1차원 배열의 좌표 요소로 투영하는 것입니다. 가령, 5x5배열에서 (4, 4) 좌표는 1차원 배열의 24번째 인덱스(몫=4, 나머지=4)로 표현가능할 것입니다.
또한, 방문 여부 체크시 이진 트리의 형태로 dfs 트리가 뻗어나가게 되는데 이를 위해서는 dfs 호출을 두 번 해주어야 합니다. [N과 M (2) 문제를 이진트리 형태로 풀이하는 영상](https://www.youtube.com/watch?v=WUq13ACJmB8&t=896s)으로부터 해당 개념에 대한 이해를 할 수 있었습니다. 

```python
# n//5, n%5 지점을 포함하는 경우
ch[n//N][n%N] = 1
dfs(n+1, cnt+1, scnt+int(arr[n//N][n%N]=='S'))
ch[n//N][n%N] = 0

# n//5, n%5 지점을 포함하지 않는 경우
dfs(n+1, cnt, scnt)
```

  <br/>

## 이미지 첨부

![image](https://github.com/user-attachments/assets/1cf34257-7fd3-4aa5-82a3-dcae8d96753d)
![image](https://github.com/user-attachments/assets/7a47db2d-8b4d-4088-a073-cd8d13a3e24e)
![image](https://github.com/user-attachments/assets/9f2a61e1-400f-4953-a464-7fdb18868339)

<br/>
